### PR TITLE
Added fastp Integration to Preprocessing Subworkflow and Update Module Metadata

### DIFF
--- a/subworkflows/local/fastqpreprocessor/meta.yml
+++ b/subworkflows/local/fastqpreprocessor/meta.yml
@@ -27,10 +27,10 @@ authors:
   - name: Josh L. Espinoza
     email: jol.espinoz@gmail.com
     github: jolespin
-  - name: Allan Philips
-    email:
+  - name: Allan Phillips
+    email: aphillip@jcvi.org
     github: 411an13
   - name: Alexa Zuniga
-    email: Alexazng@gmail.com
+    email: alexazng@gmail.com
     github: Alexaz13
   

--- a/subworkflows/local/fastqpreprocessor/meta.yml
+++ b/subworkflows/local/fastqpreprocessor/meta.yml
@@ -26,7 +26,7 @@ output:
 authors:
   - name: Josh L. Espinoza
     email: jespinoza@email.com
-    github: jespinoza
+    github: jolespin
   - name: Allan Philips
     email:
     github: 411an13

--- a/subworkflows/local/fastqpreprocessor/meta.yml
+++ b/subworkflows/local/fastqpreprocessor/meta.yml
@@ -23,4 +23,14 @@ output:
   - fastp_json: FASTP JSON report
   - versions: Software versions YAML
   - multiqc_report: MultiQC HTML report
-
+authors:
+  - name: Josh L. Espinoza
+    email: jespinoza@email.com
+    github: jespinoza
+  - name: Allan Philips
+    email:
+    github: 411an13
+  - name: Alexa Zuniga
+    email: Alexazng@gmail.com
+    github: Alexaz13
+  

--- a/subworkflows/local/fastqpreprocessor/meta.yml
+++ b/subworkflows/local/fastqpreprocessor/meta.yml
@@ -25,7 +25,7 @@ output:
   - multiqc_report: MultiQC HTML report
 authors:
   - name: Josh L. Espinoza
-    email: jespinoza@email.com
+    email: jol.espinoz@gmail.com
     github: jolespin
   - name: Allan Philips
     email:

--- a/workflows/veba.nf
+++ b/workflows/veba.nf
@@ -3,6 +3,7 @@
     IMPORT MODULES / SUBWORKFLOWS / FUNCTIONS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
+include { FASTP                  } from '../modules/nf-core/fastp/main.nf'
 include { FASTQC                 } from '../modules/nf-core/fastqc/main'
 include { MULTIQC                } from '../modules/nf-core/multiqc/main'
 include { paramsSummaryMap       } from 'plugin/nf-schema'
@@ -24,13 +25,26 @@ workflow VEBA {
 
     ch_versions = Channel.empty()
     ch_multiqc_files = Channel.empty()
+       //
+    // MODULE: Run FASTP
     //
-    // MODULE: Run FastQC
-    //
-    FASTQC (
-        ch_samplesheet
+    FASTP(
+        ch_samplesheet,
+        params.adapter_fasta,
+        params.discard_trimmed_pass,
+        params.save_trimmed_fail,
+        params.save_merged
     )
-    ch_multiqc_files = ch_multiqc_files.mix(FASTQC.out.zip.collect{it[1]})
+    ch_versions = ch_versions.mix(FASTP.out.versions.first())
+    ch_multiqc_files = ch_multiqc_files.mix(FASTP.out.json.collect { it[1] })
+
+    //
+    // MODULE: Run FastQC on trimmed reads from FASTP
+    //
+    FASTQC(
+        FASTP.out.reads
+    )
+    ch_multiqc_files = ch_multiqc_files.mix(FASTQC.out.zip.collect { it[1] })
     ch_versions = ch_versions.mix(FASTQC.out.versions.first())
 
     //


### PR DESCRIPTION
-Integrated the fastp module into the workflows/veba.nf preprocessing subworkflow to perform quality trimming and filtering prior to downstream processing. 
-Edited the fastqpreprocessor/meta.yml file to update the list of authors for clarity and attribution.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/veba/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/veba _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
